### PR TITLE
BaseClient - revert authToken variable removal and related method, sp…

### DIFF
--- a/src/main/java/com/skynest/clients/SkyNestBackendClient.java
+++ b/src/main/java/com/skynest/clients/SkyNestBackendClient.java
@@ -17,7 +17,7 @@ public class SkyNestBackendClient extends BaseClient {
         Response response = requestMaker()
                 .body(loginRequest)
                 .post("/public/login");
-        setAuthTokenIfExisting(response.getHeader(AUTHORIZATION));
+        setAuthToken(response.getHeader(AUTHORIZATION));
         return response;
     }
 

--- a/src/main/java/com/skynest/utils/JsonTransformer.java
+++ b/src/main/java/com/skynest/utils/JsonTransformer.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class BaseTransformer {
+public final class JsonTransformer {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static String objectToJson(Object payload) throws JsonProcessingException {

--- a/src/test/java/com/skynest/BaseTest.java
+++ b/src/test/java/com/skynest/BaseTest.java
@@ -6,7 +6,6 @@ import org.testng.annotations.BeforeSuite;
 import java.net.URISyntaxException;
 
 public class BaseTest {
-    //Protected access modifier because it's used in all child classes
     protected SkyNestBackendClient skyNestBackendClient;
 
     @BeforeSuite

--- a/src/test/java/com/skynest/LoginTest.java
+++ b/src/test/java/com/skynest/LoginTest.java
@@ -2,6 +2,7 @@ package com.skynest;
 
 import com.skynest.models.LoginRequest;
 import io.restassured.response.Response;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.apache.http.HttpStatus.*;
@@ -36,44 +37,9 @@ public class LoginTest extends BaseTest {
         response.then().statusCode(SC_UNAUTHORIZED);
     }
 
-    @Test
-    void user_should_not_be_logged_in_entering_invalid_email_and_valid_password() {
-        LoginRequest body = new LoginRequest("invalidemail@yahoo.com", "System123");
-        Response response = skyNestBackendClient.login(body);
-        response.then().statusCode(SC_NOT_FOUND);
-    }
-
-    @Test
-    void user_should_not_be_logged_in_entering_invalid_email_and_invalid_password() {
-        LoginRequest body = new LoginRequest("invalidemail@yahoo.com", "invalidpass");
-        Response response = skyNestBackendClient.login(body);
-        response.then().statusCode(SC_NOT_FOUND);
-    }
-
-    @Test
-    void user_should_not_be_logged_in_entering_invalid_email_and_blank_password() {
-        LoginRequest body = new LoginRequest("invalidemail@yahoo.com", "");
-        Response response = skyNestBackendClient.login(body);
-        response.then().statusCode(SC_NOT_FOUND);
-    }
-
-    @Test
-    void user_should_not_be_logged_in_entering_blank_email_and_valid_password() {
-        LoginRequest body = new LoginRequest("", "System123");
-        Response response = skyNestBackendClient.login(body);
-        response.then().statusCode(SC_NOT_FOUND);
-    }
-
-    @Test
-    void user_should_not_be_logged_in_entering_blank_email_and_invalid_password() {
-        LoginRequest body = new LoginRequest("", "invalidpass");
-        Response response = skyNestBackendClient.login(body);
-        response.then().statusCode(SC_NOT_FOUND);
-    }
-
-    @Test
-    void user_should_not_be_logged_in_entering_blank_email_and_blank_password() {
-        LoginRequest body = new LoginRequest("", "");
+    @Test(dataProvider = "invalidCredentialCombinations")
+    void user_should_not_log_in_with_invalid_credentials(String email, String password) {
+        LoginRequest body = new LoginRequest(email, password);
         Response response = skyNestBackendClient.login(body);
         response.then().statusCode(SC_NOT_FOUND);
     }
@@ -86,5 +52,17 @@ public class LoginTest extends BaseTest {
             response = skyNestBackendClient.login(body);
         }
         response.then().statusCode(429);
+    }
+
+    @DataProvider(name = "invalidCredentialCombinations")
+    public static Object[][] invalidCredentials() {
+        return new Object[][] {
+                {"invalidemail@yahoo.com", "System123"},
+                {"invalidemail@yahoo.com", "invalidpass"},
+                {"invalidemail@yahoo.com", ""},
+                {"", "System123"},
+                {"", "invalidpass"},
+                {"", ""}
+        };
     }
 }

--- a/src/test/java/com/skynest/RegistrationTest.java
+++ b/src/test/java/com/skynest/RegistrationTest.java
@@ -4,13 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.skynest.models.ApiConstants;
 import com.skynest.models.RegistrationRequest;
 import com.skynest.models.RegistrationResponse;
-import com.skynest.utils.BaseTransformer;
+import com.skynest.utils.JsonTransformer;
 import io.restassured.response.Response;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 
 public class RegistrationTest extends BaseTest {
 
@@ -18,8 +20,8 @@ public class RegistrationTest extends BaseTest {
     void registering_new_valid_user_should_return_specified_response
             (RegistrationRequest registrationPayload) throws JsonProcessingException {
 
-        Response response = given().log().all().header("Content-Type", "application/json")
-                .body(BaseTransformer.objectToJson(registrationPayload))
+        Response response = given().log().all().header(CONTENT_TYPE, APPLICATION_JSON)
+                .body(JsonTransformer.objectToJson(registrationPayload))
                 .when().post(ApiConstants.REGISTER_ENDPOINT);
 
         RegistrationResponse registrationResponse = response.as(RegistrationResponse.class);


### PR DESCRIPTION
…ace out complex object instantiation in constructor, break up requestMaker into smaller functions; rename BaseTransformer to better reflect its responsibility; combine several LoginTest methods into single parameterized test; use readily available enums for header name constants